### PR TITLE
fix: replace nvim_win_close hack for neo-tree compatibility

### DIFF
--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -189,7 +189,7 @@ split_sidebar_left() {
     then
         # HACK: using `:Neotree current` command makes the tree incompletely initialized.
         # So we open on the side and close the default empty window instead.
-        common_args="$common_args +Neotree '+lua vim.api.nvim_win_close(1000, false)'"
+        common_args="$common_args '+Neotree current reveal'"
     else
         echo "Unknown TREE_CLIENT: $TREE_CLIENT"
         exit 1
@@ -233,7 +233,7 @@ split_sidebar_right() {
     then
         # HACK: using `:Neotree current` command makes the tree incompletely initialized.
         # So we open on the side and close the default empty window instead.
-        common_args="$common_args +Neotree '+lua vim.api.nvim_win_close(1000, false)'"
+        common_args="$common_args '+Neotree current reveal'"
     else
         echo "Unknown TREE_CLIENT: $TREE_CLIENT"
         exit 1


### PR DESCRIPTION
## Summary

- The `vim.api.nvim_win_close(1000, false)` hack in `toggle.sh` crashes nvim when window 1000 doesn't exist (e.g. with AstroNvim or other distributions)
- Replaced with `Neotree current reveal` which opens neo-tree directly in the current window without needing to close a default buffer
- Fixes both `split_sidebar_left()` and `split_sidebar_right()` functions

## Test plan

- [ ] Open treemux sidebar with `@treemux-tree-client` set to `neo-tree`
- [ ] Verify sidebar opens without errors
- [ ] Verify file tree displays correctly
- [ ] Test with AstroNvim and vanilla nvim + neo-tree